### PR TITLE
Support Newer Lenovo Clickpads

### DIFF
--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -1032,6 +1032,10 @@ void ApplePS2SynapticsTouchPad::dispatchEventsWithPacket(UInt8* packet, UInt32 p
     // now deal with pass through packet moving/scrolling
     if (passthru && 3 == w)
     {
+        // New lenvo clickpads do not have buttons, so LR in packet byte 1 is zero and thus
+        // passbuttons is 0.  Instead we need to check the trackpad buttons in byte 0 and byte 3
+        UInt32 combinedButtons = passbuttons | (packet[0] & 0x3) | (packet[3] & 0x3);
+
         SInt32 dx = ((packet[1] & 0x10) ? 0xffffff00 : 0 ) | packet[4];
         SInt32 dy = ((packet[1] & 0x20) ? 0xffffff00 : 0 ) | packet[5];
         if (mousemiddlescroll && (packet[1] & 0x4)) // only for physical middle button
@@ -1047,10 +1051,10 @@ void ApplePS2SynapticsTouchPad::dispatchEventsWithPacket(UInt8* packet, UInt32 p
         }
         dx *= mousemultiplierx;
         dy *= mousemultipliery;
-        dispatchRelativePointerEventX(dx, -dy, buttons, now_abs);
+        dispatchRelativePointerEventX(dx, -dy, combinedButtons, now_abs);
 #ifdef DEBUG_VERBOSE
         static int count = 0;
-        IOLog("ps2: passthru packet dx=%d, dy=%d, buttons=%d (%d)\n", dx, dy, buttons, count++);
+        IOLog("ps2: passthru packet dx=%d, dy=%d, buttons=%d (%d)\n", dx, dy, combinedButtons, count++);
 #endif
         return;
     }


### PR DESCRIPTION
Fix for newer lenovo trackpads that do not have separate track point buttons (T431 models and higher).  Fixes #14.
