### PR TITLE
Fix Right Click on Lenovo Integrated Trackpads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+#JC Snider's Modified VoodooPs2Controller based off of Rehabman's Modified VoodooPS2Controller (see below).
+My edits are for my own personal Thinkpad Carbon X1 (3rd Gen) 20BS. As of now (Yosemite 10.10.3 release, April 2015) these edits fix the super sensitive Trackpoint and fix the dedicated buttons so the operate properly.  This mod *might* work for other 2015 Broadwell Thinkpads with the new keyboards/dedicated trackpoint buttons but there are obviously no guarentees.
+
+This project compiles perfectly fine in XCode 6.3 targetting the OSX 10.9 SDK.
+
+You can find the compiled .kext here, works for 64bit machines and maybe 32bit, I never checked.
+http://www.tonymacx86.com/yosemite-laptop-support/162195-thinkpad-x1-carbon-3rd-gen-could-use-some-hints.html#post1024374
+
+
 ## Modified VoodooPS2Controller by RehabMan
 
 

--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -792,7 +792,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_POSTPROCESSING = YES;
@@ -814,7 +813,6 @@
 				MODULE_VERSION = 1.8.25;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
-				SDKROOT = macosx10.8;
 				SYMROOT = build/Products;
 			};
 			name = Debug;
@@ -823,7 +821,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_POSTPROCESSING = YES;
@@ -839,7 +836,6 @@
 				MODULE_VERSION = 1.8.25;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
-				SDKROOT = macosx10.8;
 				SYMROOT = build/Products;
 			};
 			name = Release;

--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -792,6 +792,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_POSTPROCESSING = YES;
@@ -813,7 +814,7 @@
 				MODULE_VERSION = 1.8.25;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
-				SDKROOT = macosx;
+				SDKROOT = macosx10.8;
 				SYMROOT = build/Products;
 			};
 			name = Debug;
@@ -822,6 +823,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_POSTPROCESSING = YES;
@@ -837,7 +839,7 @@
 				MODULE_VERSION = 1.8.25;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
-				SDKROOT = macosx;
+				SDKROOT = macosx10.8;
 				SYMROOT = build/Products;
 			};
 			name = Release;

--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -794,7 +794,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_POSTPROCESSING = YES;
@@ -816,7 +815,7 @@
 				MODULE_VERSION = 1.8.24;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
-				SDKROOT = macosx10.8;
+				SDKROOT = macosx;
 				SYMROOT = build/Products;
 			};
 			name = Debug;
@@ -825,7 +824,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_POSTPROCESSING = YES;
@@ -841,7 +839,7 @@
 				MODULE_VERSION = 1.8.24;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
-				SDKROOT = macosx10.8;
+				SDKROOT = macosx;
 				SYMROOT = build/Products;
 			};
 			name = Release;

--- a/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/All.xcscheme
+++ b/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/All.xcscheme
@@ -126,7 +126,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/All.xcscheme
+++ b/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/All.xcscheme
@@ -126,7 +126,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -24,10 +24,10 @@
 //#define SIMULATE_CLICKPAD
 //#define SIMULATE_PASSTHRU
 
-//#define FULL_HW_RESET
+#define FULL_HW_RESET
 //#define SET_STREAM_MODE
 //#define UNDOCUMENTED_INIT_SEQUENCE_PRE
-#define UNDOCUMENTED_INIT_SEQUENCE_POST
+//#define UNDOCUMENTED_INIT_SEQUENCE_POST
 
 // enable for trackpad debugging
 #ifdef DEBUG_MSG

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
@@ -394,6 +394,8 @@ private:
     UInt32 middleButton(UInt32 butttons, uint64_t now, MBComingFrom from);
     
     void setParamPropertiesGated(OSDictionary* dict);
+    
+    int trackPointOverride = 0;
 
 protected:
 	virtual IOItemCount buttonCount();

--- a/VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist
+++ b/VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist
@@ -223,13 +223,13 @@
 					<key>DisableLEDUpdating</key>
 					<false/>
 					<key>MouseMultiplierX</key>
-					<integer>20</integer>
+					<integer>2</integer>
 					<key>MouseMultiplierY</key>
-					<integer>20</integer>
+					<integer>2</integer>
 					<key>MouseScrollMultiplierX</key>
-					<integer>20</integer>
+					<integer>1</integer>
 					<key>MouseScrollMultiplierY</key>
-					<integer>20</integer>
+					<integer>1</integer>
 					<key>MouseMiddleScroll</key>
 					<true/>
 					<key>WakeDelay</key>


### PR DESCRIPTION
This is a follow up to my patch last spring for the new Lenovo integrated trackpads (t431s and up).  This enables pressing the right hand side of the track pad to enable mouse right-click.
