### PR TITLE
Only change the Caps lock to Left Control

### DIFF
--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -814,7 +814,7 @@
 				MODULE_VERSION = 1.8.28;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
-				SDKROOT = macosx10.8;
+				SDKROOT = macosx10.13;
 				SYMROOT = build/Products;
 			};
 			name = Debug;
@@ -839,7 +839,7 @@
 				MODULE_VERSION = 1.8.28;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
-				SDKROOT = macosx10.8;
+				SDKROOT = macosx10.13;
 				SYMROOT = build/Products;
 			};
 			name = Release;

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
@@ -58,6 +58,8 @@
 					<false/>
 					<key>Swap capslock and left control</key>
 					<false/>
+					<key>CHANGE capslock to left control</key>
+					<false/>
 					<key>Swap command and option</key>
 					<true/>
 					<key>Use ISO layout keyboard</key>

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
@@ -5,7 +5,7 @@
 	<key>Source Code</key>
 	<string>https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller</string>
 	<key>CFBundleGetInfoString</key>
-	<string>${MODULE_VERSION}, Copyright Apple Computer, Inc. 2000-2003, RehabMan 2012-2013</string>
+	<string>${MODULE_VERSION}-hvt, Copyright Apple Computer, Inc. 2000-2003, RehabMan 2012-2013, my mod</string>
 	<key>CFBundleExecutable</key>
 	<string>VoodooPS2Keyboard</string>
 	<key>CFBundleIdentifier</key>
@@ -59,9 +59,9 @@
 					<key>Swap capslock and left control</key>
 					<false/>
 					<key>CHANGE capslock to left control</key>
-					<false/>
-					<key>Swap command and option</key>
 					<true/>
+					<key>Swap command and option</key>
+					<false/>
 					<key>Use ISO layout keyboard</key>
 					<false/>
 					<key>alt_handler_id</key>

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -844,7 +844,7 @@ void ApplePS2Keyboard::setParamPropertiesGated(OSDictionary * dict)
     }
     //If kSwapCapsLockLeftControl is True, then we do NOT implement this
     if (xml2) {
-        if (xml2->isTrue() && (getProperty(kSwapCapsLockLeftControl) = kOSBooleanFalse)) {
+        if (xml2->isTrue() && (getProperty(kSwapCapsLockLeftControl) == kOSBooleanFalse)) {
             _PS2ToADBMap[0x3a]  = _PS2ToADBMapMapped[0x1d];
         }
         setProperty(kChangeCapsLockLeftControl, xml2->isTrue() ? kOSBooleanTrue : kOSBooleanFalse);

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -55,6 +55,7 @@ void* _org_rehabman_dontstrip_[] =
 #define kFunctionKeysStandard               "Function Keys Standard"
 #define kFunctionKeysSpecial                "Function Keys Special"
 #define kSwapCapsLockLeftControl            "Swap capslock and left control"
+#define kChangeCapsLockLeftControl          "CHANGE capslock to left control"
 #define kSwapCommandOption                  "Swap command and option"
 #define kMakeApplicationKeyRightWindows     "Make Application key into right windows"
 #define kMakeApplicationKeyAppleFN          "Make Application key into Apple Fn key"
@@ -829,6 +830,7 @@ void ApplePS2Keyboard::setParamPropertiesGated(OSDictionary * dict)
     // Configure user preferences from Info.plist
     //
     OSBoolean* xml = OSDynamicCast(OSBoolean, dict->getObject(kSwapCapsLockLeftControl));
+    OSBoolean* xml2 = OSDynamicCast(OSBoolean, dict->getObject(kChangeCapsLockLeftControl));
     if (xml) {
         if (xml->isTrue()) {
             _PS2ToADBMap[0x3a]  = _PS2ToADBMapMapped[0x1d];
@@ -839,6 +841,13 @@ void ApplePS2Keyboard::setParamPropertiesGated(OSDictionary * dict)
             _PS2ToADBMap[0x1d]  = _PS2ToADBMapMapped[0x1d];
         }
         setProperty(kSwapCapsLockLeftControl, xml->isTrue() ? kOSBooleanTrue : kOSBooleanFalse);
+    }
+    //If kSwapCapsLockLeftControl is True, then we do NOT implement this
+    if (xml2) {
+        if (xml2->isTrue() && (getProperty(kSwapCapsLockLeftControl) = kOSBooleanFalse)) {
+            _PS2ToADBMap[0x3a]  = _PS2ToADBMapMapped[0x1d];
+        }
+        setProperty(kChangeCapsLockLeftControl, xml2->isTrue() ? kOSBooleanTrue : kOSBooleanFalse);
     }
     
     xml = OSDynamicCast(OSBoolean, dict->getObject(kSwapCommandOption));


### PR DESCRIPTION
Hi there,

 I don't need the Caps Lock and want to still keep the left control for others on my keyboard, so
this change should only change the CapsLock.

The Logic: Implement this if the plist entry `"CHANGE capslock to left control" `is True, and the `"Swap capslock and left control"` entry is False
