### PR TITLE
Refactored notification subscription for 3rd party drivers

### DIFF
--- a/VoodooPS2Controller/AppleACPIPS2Nub.h
+++ b/VoodooPS2Controller/AppleACPIPS2Nub.h
@@ -35,9 +35,9 @@
 #include <IOKit/IOPlatformExpert.h>
 #include <IOKit/acpi/IOACPITypes.h>
 
-#define EXPORT __attribute__((visibility("default")))
+#include "ApplePS2Device.h"
 
-#define kDeliverNotifications   "RM,deliverNotifications"
+#define EXPORT __attribute__((visibility("default")))
 
 class IOPlatformExpert;
 

--- a/VoodooPS2Controller/ApplePS2Device.cpp
+++ b/VoodooPS2Controller/ApplePS2Device.cpp
@@ -133,24 +133,9 @@ void ApplePS2Device::uninstallPowerControlAction()
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-void ApplePS2Device::installMessageAction(OSObject* target, PS2MessageAction action)
+void ApplePS2Device::dispatchMessage(int message, void *data)
 {
-    _controller->installMessageAction(_deviceType, target, action);
-}
-
-void ApplePS2Device::uninstallMessageAction()
-{
-    _controller->uninstallMessageAction(_deviceType);
-}
-
-void ApplePS2Device::dispatchMouseMessage(int message, void *data)
-{
-    _controller->dispatchMessage(kDT_Mouse, message, data);
-}
-
-void ApplePS2Device::dispatchKeyboardMessage(int message, void *data)
-{
-    _controller->dispatchMessage(kDT_Keyboard, message, data);
+    _controller->dispatchMessage(message, data);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -511,20 +511,25 @@ typedef void (*PS2PowerControlAction)(void * target, UInt32 whatToDo);
 // the keyboard driver.
 //
 
+// Published property for devices to express interest in receiving messages
+#define kDeliverNotifications   "RM,deliverNotifications"
+
 typedef void (*PS2MessageAction)(void* target, int message, void* data);
 
 enum
 {
     // from keyboard to mouse/touchpad
-    kPS2M_setDisableTouchpad,   // set disable/enable touchpad (data is bool*)
-    kPS2M_getDisableTouchpad,   // get disable/enable touchpad (data is bool*)
-    kPS2M_notifyKeyPressed,     // notify of time key pressed (data is PS2KeyInfo*)
+    kPS2M_setDisableTouchpad = iokit_vendor_specific_msg(100),   // set disable/enable touchpad (data is bool*)
+    kPS2M_getDisableTouchpad = iokit_vendor_specific_msg(101),   // get disable/enable touchpad (data is bool*)
+    kPS2M_notifyKeyPressed = iokit_vendor_specific_msg(102),     // notify of time key pressed (data is PS2KeyInfo*)
     
     // from mouse/touchpad to keyboard
-    kPS2M_swipeDown,
-    kPS2M_swipeUp,
-    kPS2M_swipeLeft,
-    kPS2M_swipeRight,
+    kPS2M_swipeDown = iokit_vendor_specific_msg(103),
+    kPS2M_swipeUp = iokit_vendor_specific_msg(104),
+    kPS2M_swipeLeft = iokit_vendor_specific_msg(105),
+    kPS2M_swipeRight = iokit_vendor_specific_msg(106),
+    
+    kPS2M_notifyKeyTime = iokit_vendor_specific_msg(110)        // notify of timestamp a non-modifier key was pressed (data is uint64_t*)
 };
 
 typedef struct PS2KeyInfo
@@ -595,11 +600,7 @@ public:
     virtual void uninstallPowerControlAction();
 
     // Messaging
-
-    virtual void installMessageAction(OSObject*, PS2MessageAction);
-    virtual void uninstallMessageAction();
-    virtual void dispatchMouseMessage(int message, void *data);
-    virtual void dispatchKeyboardMessage(int message, void *data);
+    virtual void dispatchMessage(int message, void *data);
 
     // Exclusive access (command byte contention)
 

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -329,13 +329,6 @@ bool ApplePS2Controller::init(OSDictionary* dict)
   _powerControlInstalledKeyboard = false;
   _powerControlInstalledMouse = false;
     
-  _messageTargetKeyboard = 0;
-  _messageTargetMouse = 0;
-  _messageActionKeyboard = 0;
-  _messageActionMouse = 0;
-  _messageInstalledKeyboard = false;
-  _messageInstalledMouse = false;
-
   _mouseDevice    = 0;
   _keyboardDevice = 0;
   
@@ -532,6 +525,26 @@ bool ApplePS2Controller::start(IOService * provider)
   setProperty("RM,Build", "Release-" LOGNAME);
 #endif
 
+  _notificationServices = OSSet::withCapacity(1);
+  OSDictionary * propertyMatch = propertyMatching(OSSymbol::withCString(kDeliverNotifications), OSBoolean::withBoolean(true));
+    
+  //
+  // Register notifications for availability of any IOService objects wanting to consume our message events
+  //
+  _publishNotify = addMatchingNotification(gIOFirstPublishNotification,
+                                           propertyMatch,
+                                           &notificationHandler,
+                                           this,
+                                           0, 10000);
+    
+   _terminateNotify = addMatchingNotification(gIOTerminatedNotification,
+                                              propertyMatch,
+                                              &notificationHandler,
+                                              this,
+                                              0, 10000);
+    
+   propertyMatch->release();
+ 
  //
  // The driver has been instructed to start.  Allocate all our resources.
  //
@@ -698,13 +711,21 @@ void ApplePS2Controller::stop(IOService * provider)
   // connections to other service objects now (ie. no registered actions,
   // no pointers and retains to objects, etc), if any.
   //
-
+    
   // Ensure that the interrupt handlers have been uninstalled (ie. no clients).
   assert(!_interruptInstalledKeyboard);
   assert(!_interruptInstalledMouse);
   assert(!_powerControlInstalledKeyboard);
   assert(!_powerControlInstalledMouse);
 
+  // Free device matching notifiers
+  _publishNotify->remove();
+  _terminateNotify->remove();
+  OSSafeReleaseNULL(_publishNotify);
+  OSSafeReleaseNULL(_terminateNotify);
+    
+  OSSafeReleaseNULL(_notificationServices);
+    
   // Free the nubs we created.
   OSSafeReleaseNULL(_keyboardDevice);
   OSSafeReleaseNULL(_mouseDevice);
@@ -2016,53 +2037,61 @@ void ApplePS2Controller::uninstallPowerControlAction( PS2DeviceType deviceType )
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-void ApplePS2Controller::installMessageAction(
-                                              PS2DeviceType deviceType,
-                                              OSObject *target, PS2MessageAction action)
+bool ApplePS2Controller::notificationHandler(
+                                        void * target, void * ref,
+                                        IOService * service, IONotifier * notifier)
 {
-    if (deviceType == kDT_Keyboard && !_messageInstalledKeyboard)
-    {
-        target->retain();
-        _messageTargetKeyboard = target;
-        _messageActionKeyboard = action;
-        _messageInstalledKeyboard = true;
+    ApplePS2Controller* self = (ApplePS2Controller*)target;
+    
+    if (notifier == self->_publishNotify) {
+        IOLog("%s: Notification consumer published: %s\n", self->getName(), service->getName());
+        self->_notificationServices->setObject(service);
     }
-    else if (deviceType == kDT_Mouse && !_messageInstalledMouse)
-    {
-        target->retain();
-        _messageTargetMouse = target;
-        _messageActionMouse = action;
-        _messageInstalledMouse = true;
+    
+    if (notifier == self->_terminateNotify) {
+        IOLog("%s: Notification consumer terminated: %s\n", self->getName(), service->getName());
+        self->_notificationServices->removeObject(service);
     }
+
+    return true;
 }
 
-void ApplePS2Controller::uninstallMessageAction(PS2DeviceType deviceType)
+void ApplePS2Controller::dispatchMessage(int message, void* data)
 {
-    if (deviceType == kDT_Keyboard && _messageInstalledKeyboard)
-    {
-        _messageInstalledKeyboard = false;
-        _messageActionKeyboard = NULL;
-        _messageTargetKeyboard->release();
-        _messageTargetKeyboard = NULL;
+    OSCollectionIterator* i = OSCollectionIterator::withCollection(_notificationServices);
+    
+    if (i != NULL) {
+        while (IOService* service = OSDynamicCast(IOService, i->getNextObject()))  {
+            service->message(message, this, data);
+        }
     }
-    else if (deviceType == kDT_Mouse && _messageInstalledMouse)
-    {
-        _messageInstalledMouse = false;
-        _messageActionMouse = NULL;
-        _messageTargetMouse->release();
-        _messageTargetMouse = NULL;
-    }
-}
-
-void ApplePS2Controller::dispatchMessage(PS2DeviceType deviceType, int message, void* data)
-{
-    if (deviceType == kDT_Keyboard && _messageInstalledKeyboard)
-    {
-        (*_messageActionKeyboard)(_messageTargetKeyboard, message, data);
-    }
-    else if (deviceType == kDT_Mouse && _messageInstalledMouse)
-    {
-        (*_messageActionMouse)(_messageTargetMouse, message, data);
+    
+    i->release();
+    
+    // Convert kPS2M_notifyKeyPressed events into additional kPS2M_notifyKeyTime events for external consumers
+    if (message == kPS2M_notifyKeyPressed) {
+        
+        // Register last key press, used for palm detection
+        PS2KeyInfo* pInfo = (PS2KeyInfo*)data;
+        
+        switch (pInfo->adbKeyCode)
+        {
+                // Do not trigger on modifier key down presses (for example multi-click select)
+            case 0x38:  // left shift
+            case 0x3c:  // right shift
+            case 0x3b:  // left control
+            case 0x3e:  // right control
+            case 0x3a:  // left windows (option)
+            case 0x3d:  // right windows
+            case 0x37:  // left alt (command)
+            case 0x36:  // right alt
+            case 0x3f:  // osx fn (function)
+                if (!pInfo->goingDown)
+                    dispatchMessage(kPS2M_notifyKeyTime, &(pInfo->time));
+                break;
+            default:
+                dispatchMessage(kPS2M_notifyKeyTime, &(pInfo->time));
+        }
     }
 }
 

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -382,7 +382,7 @@ ApplePS2Controller* ApplePS2Controller::probe(IOService* provider, SInt32* probe
         setProperty(kMergedConfiguration, config);
 #endif
     setPropertiesGated(config);
-    OSSafeRelease(config);
+    OSSafeReleaseNULL(config);
 
     return this;
 }
@@ -2250,7 +2250,7 @@ static OSDictionary* _getConfigurationNode(OSDictionary *root, const char *name)
         
         configuration = _getConfigurationNode(root, nameNode);
         
-        OSSafeRelease(nameNode);
+        OSSafeReleaseNULL(nameNode);
     }
     
     return configuration;
@@ -2355,7 +2355,7 @@ OSObject* ApplePS2Controller::translateArray(OSArray* array)
             if (trans)
                 obj = trans;
             dict->setObject(key, obj);
-            OSSafeRelease(trans);
+            OSSafeReleaseNULL(trans);
         }
         result = dict;
     }
@@ -2376,13 +2376,13 @@ OSDictionary* ApplePS2Controller::getConfigurationOverride(IOACPIPlatformDevice*
     OSArray* array = OSDynamicCast(OSArray, r);
     if (array)
         obj = translateArray(array);
-    OSSafeRelease(r);
+    OSSafeReleaseNULL(r);
 
     // must be dictionary after translation, even though array is possible
     OSDictionary* result = OSDynamicCast(OSDictionary, obj);
     if (!result)
     {
-        OSSafeRelease(obj);
+        OSSafeReleaseNULL(obj);
         return NULL;
     }
     return result;

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -366,6 +366,8 @@ bool ApplePS2Controller::init(OSDictionary* dict)
   if (!_controllerLock) return false;
 #endif //DEBUGGER_SUPPORT
     
+  _notificationServices = OSSet::withCapacity(1);
+    
   return true;
 }
 
@@ -525,7 +527,6 @@ bool ApplePS2Controller::start(IOService * provider)
   setProperty("RM,Build", "Release-" LOGNAME);
 #endif
 
-  _notificationServices = OSSet::withCapacity(1);
   OSDictionary * propertyMatch = propertyMatching(OSSymbol::withCString(kDeliverNotifications), OSBoolean::withBoolean(true));
     
   //
@@ -724,6 +725,7 @@ void ApplePS2Controller::stop(IOService * provider)
   OSSafeReleaseNULL(_publishNotify);
   OSSafeReleaseNULL(_terminateNotify);
     
+  _notificationServices->flushCollection();
   OSSafeReleaseNULL(_notificationServices);
     
   // Free the nubs we created.

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -2076,7 +2076,7 @@ void ApplePS2Controller::dispatchMessage(int message, void* data)
         
         switch (pInfo->adbKeyCode)
         {
-                // Do not trigger on modifier key down presses (for example multi-click select)
+            // Do not trigger on modifier key presses (for example multi-click select)
             case 0x38:  // left shift
             case 0x3c:  // right shift
             case 0x3b:  // left control
@@ -2086,8 +2086,6 @@ void ApplePS2Controller::dispatchMessage(int message, void* data)
             case 0x37:  // left alt (command)
             case 0x36:  // right alt
             case 0x3f:  // osx fn (function)
-                if (!pInfo->goingDown)
-                    dispatchMessage(kPS2M_notifyKeyTime, &(pInfo->time));
                 break;
             default:
                 dispatchMessage(kPS2M_notifyKeyTime, &(pInfo->time));

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -278,7 +278,7 @@ private:
   static void interruptHandlerMouse(OSObject*, void* refCon, IOService*, int);
   static void interruptHandlerKeyboard(OSObject*, void* refCon, IOService*, int);
    
-  static bool notificationHandler(void* target, void* ref_con, IOService* service, IONotifier* notifier);
+  bool notificationHandler(void * refCon, IOService * newService, IONotifier * notifier);
     
 #if OUT_OF_ORDER_DATA_CORRECTION_FEATURE
   virtual UInt8 readDataPort(PS2DeviceType deviceType, UInt8 expectedByte);

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -221,16 +221,14 @@ private:
   int                      _ignoreInterrupts;
   int                      _ignoreOutOfOrder;
     
-  OSObject*                _messageTargetKeyboard;
-  OSObject*                _messageTargetMouse;
-  PS2MessageAction         _messageActionKeyboard;
-  PS2MessageAction         _messageActionMouse;
-  bool                     _messageInstalledKeyboard;
-  bool                     _messageInstalledMouse;
-
   ApplePS2MouseDevice *    _mouseDevice;          // mouse nub
   ApplePS2KeyboardDevice * _keyboardDevice;       // keyboard nub
 
+  IONotifier*              _publishNotify;
+  IONotifier*              _terminateNotify;
+    
+  OSSet*                   _notificationServices;
+    
 #if DEBUGGER_SUPPORT
   IOSimpleLock *           _controllerLock;       // mach simple spin lock
 
@@ -279,6 +277,8 @@ private:
     
   static void interruptHandlerMouse(OSObject*, void* refCon, IOService*, int);
   static void interruptHandlerKeyboard(OSObject*, void* refCon, IOService*, int);
+   
+  static bool notificationHandler(void* target, void* ref_con, IOService* service, IONotifier* notifier);
     
 #if OUT_OF_ORDER_DATA_CORRECTION_FEATURE
   virtual UInt8 readDataPort(PS2DeviceType deviceType, UInt8 expectedByte);
@@ -328,12 +328,7 @@ public:
 
   virtual void uninstallPowerControlAction(PS2DeviceType deviceType);
     
-  virtual void installMessageAction(PS2DeviceType         deviceType,
-                                    OSObject *            target,
-                                    PS2MessageAction action);
-    
-  virtual void uninstallMessageAction(PS2DeviceType deviceType);
-  virtual void dispatchMessage(PS2DeviceType deviceType, int message, void* data);
+  virtual void dispatchMessage(int message, void* data);
     
   virtual IOReturn setProperties(OSObject* props);
   virtual void lock();

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -354,7 +354,7 @@ ApplePS2Keyboard* ApplePS2Keyboard::probe(IOService * provider, SInt32 * score)
     
     // populate rest of values via setParamProperties
     setParamPropertiesGated(config);
-    OSSafeRelease(config);
+    OSSafeReleaseNULL(config);
     
 #ifdef DEBUG
     logKeySequence("Swipe Up:", _actionSwipeUp);
@@ -1768,8 +1768,8 @@ bool ApplePS2Keyboard::dispatchKeyboardEventWithPacket(const UInt8* packet)
                             dict->release();
                         }
                     }
-                    OSSafeRelease(num);
-                    OSSafeRelease(key);
+                    OSSafeReleaseNULL(num);
+                    OSSafeReleaseNULL(key);
                     service->release();
                 }
             }

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -79,7 +79,6 @@ private:
     UInt8                       _lastdata;
     bool                        _interruptHandlerInstalled;
     bool                        _powerControlHandlerInstalled;
-    bool                        _messageHandlerInstalled;
     UInt8                       _ledState;
     IOCommandGate*              _cmdGate;
 
@@ -174,8 +173,6 @@ public:
 
     virtual PS2InterruptResult interruptOccurred(UInt8 scanCode);
     virtual void packetReady();
-    
-    virtual void receiveMessage(int message, void* data);
     
     virtual UInt32 deviceType();
     virtual UInt32 interfaceID();

--- a/VoodooPS2Mouse/VoodooPS2Mouse.cpp
+++ b/VoodooPS2Mouse/VoodooPS2Mouse.cpp
@@ -313,7 +313,7 @@ ApplePS2Mouse* ApplePS2Mouse::probe(IOService * provider, SInt32 * score)
   setParamPropertiesGated(config);
   if (actliketrackpad)
     injectVersionDependentProperties(config);
-  OSSafeRelease(config);
+  OSSafeReleaseNULL(config);
 
   // remove some properties so system doesn't think it is a trackpad
   // this should cause "Product" = "Mouse" in ioreg.
@@ -1305,6 +1305,8 @@ IOReturn ApplePS2Mouse::message(UInt32 type, IOService* provider, void* argument
             break;
         }
     }
+    
+    return kIOReturnSuccess;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/VoodooPS2Mouse/VoodooPS2Mouse.h
+++ b/VoodooPS2Mouse/VoodooPS2Mouse.h
@@ -56,7 +56,6 @@ private:
   ApplePS2MouseDevice * _device;
   bool                  _interruptHandlerInstalled;
   bool                  _powerControlHandlerInstalled;
-  bool                  _messageHandlerInstalled;
   RingBuffer<UInt8, kPacketLengthMax*32> _ringBuffer;
   UInt32                _packetByteCount;
   UInt8                 _lastdata;
@@ -119,7 +118,6 @@ private:
   virtual void   initMouse();
   virtual void   resetMouse();
   virtual void   setDevicePowerState(UInt32 whatToDo);
-  virtual void   receiveMessage(int message, void* data);
     
   void updateTouchpadLED();
   bool setTouchpadLED(UInt8 touchLED);
@@ -154,6 +152,8 @@ public:
     
   virtual IOReturn setParamProperties(OSDictionary * dict);
   virtual IOReturn setProperties (OSObject *props);
+    
+  virtual IOReturn message(UInt32 type, IOService* provider, void* argument);
 };
 
 #endif /* _APPLEPS2MOUSE_H */

--- a/VoodooPS2Trackpad/VoodooPS2ALPSGlidePoint.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2ALPSGlidePoint.cpp
@@ -98,7 +98,7 @@ ApplePS2ALPSGlidePoint* ApplePS2ALPSGlidePoint::probe( IOService * provider, SIn
         setProperty(kMergedConfiguration, config);
 #endif
     }
-    OSSafeRelease(config);
+    OSSafeReleaseNULL(config);
 
 	ALPSStatus_t E6,E7;
     //

--- a/VoodooPS2Trackpad/VoodooPS2SentelicFSP.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SentelicFSP.cpp
@@ -273,7 +273,7 @@ ApplePS2SentelicFSP* ApplePS2SentelicFSP::probe( IOService * provider, SInt32 * 
         setProperty(kMergedConfiguration, config);
 #endif
     }
-    OSSafeRelease(config);
+    OSSafeReleaseNULL(config);
 
     bool success = false;
     TPS2Request<> request;

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -338,7 +338,7 @@ ApplePS2SynapticsTouchPad* ApplePS2SynapticsTouchPad::probe(IOService * provider
     // load settings specific to Platform Profile
     setParamPropertiesGated(config);
     injectVersionDependentProperties(config);
-    OSSafeRelease(config);
+    OSSafeReleaseNULL(config);
 
     // for diagnostics...
     UInt8 buf3[3];
@@ -2973,6 +2973,8 @@ IOReturn ApplePS2SynapticsTouchPad::message(UInt32 type, IOService* provider, vo
             break;
         }
     }
+    
+    return kIOReturnSuccess;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
@@ -169,7 +169,6 @@ private:
     ApplePS2MouseDevice * _device;
     bool                _interruptHandlerInstalled;
     bool                _powerControlHandlerInstalled;
-    bool                _messageHandlerInstalled;
     RingBuffer<UInt8, kPacketLength*32> _ringBuffer;
     UInt32              _packetByteCount;
     UInt8               _lastdata;
@@ -387,8 +386,6 @@ private:
     virtual void packetReady();
     virtual void   setDevicePowerState(UInt32 whatToDo);
     
-    virtual void   receiveMessage(int message, void* data);
-    
     void updateTouchpadLED();
     bool setTouchpadLED(UInt8 touchLED);
     bool setTouchpadModeByte(); // set based on state
@@ -436,6 +433,8 @@ public:
 
 	virtual IOReturn setParamProperties(OSDictionary * dict);
 	virtual IOReturn setProperties(OSObject *props);
+    
+    virtual IOReturn message(UInt32 type, IOService* provider, void* argument);
 };
 
 #endif /* _APPLEPS2SYNAPTICSTOUCHPAD_H */


### PR DESCRIPTION
The existing `ApplePS2Controller` allows `ApplePS2Device` derived devices to register for notification events (keyboard to touchpad/mouse and vice versa)

However, the way this is implemented makes it limited to ApplePS2Device derived devices and allows only one keyboard and mouse registration.

The refactored approach uses `IOService::addMatchingNotification` based on property matching using the key `RM,deliverNotifications` (based on `AppleACPIPS2Nub` messaging)

As devices are published, they are added in a notification collection to which `IOService::message` events are dispatched.

It does not use `IOService:messageClient` or `IOService::messageClients` but rather invokes `IOService::message` directly (similar to `AppleACPIPS2Nub`).

Using this approach allows it to dispatch notifications to any `IOService` object without having to know more about its internal structure. This opens sending notifications to any 3rd party driver.

An implementation of this is done for VoodooI2CHID, which allows controlling the touchpad with `PrtScr` as well as ignoring accidental palm touches while typing.

As part of the new messaging implementation, the old approach of installMessageAction and separate dispatching of mouse and keyboard messages has been refactored.

Example integration for VoodooI2CHID can be found in the following pull request:
https://github.com/alexandred/VoodooI2CHID/pull/6