### PR TITLE
Typo: UnsmootInput -> UnsmoothInput

### DIFF
--- a/SSDT-Thinkpad_Clickpad.dsl
+++ b/SSDT-Thinkpad_Clickpad.dsl
@@ -32,7 +32,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "ps2", 0)
                 "PalmNoAction When Typing", ">y",
                 "ScrollResolution", 800,
                 "SmoothInput", ">y",
-                "UnsmootInput", ">y",
+                "UnsmoothInput", ">y",
                 "Thinkpad", ">y",
                 "EdgeBottom", 0,
                 "FingerZ", 30,


### PR DESCRIPTION
Everywhere else in the code, it's spelled `UnsmoothInput` except here.